### PR TITLE
Show keyframe styles in place

### DIFF
--- a/src/ActiveMarker.tsx
+++ b/src/ActiveMarker.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 
 interface ActiveMarkerProps {
   activeMarker?: Marker;
@@ -11,6 +12,11 @@ interface KeyframeBlockProps {
   percentage: number;
   active?: boolean;
 }
+
+const ActiveMarkerWrapper = styled.div`
+  flex-basis: 20vw;
+  padding: 20px;
+`;
 
 const KeyframeBlock = ({ title, keyframe, percentage }: KeyframeBlockProps) => {
   return (
@@ -46,7 +52,7 @@ export const ActiveMarker = ({ activeMarker, tracks }: ActiveMarkerProps) => {
       (kf) => kf.id === activeMarker?.keyframeId
     );
     return (
-      <div>
+      <ActiveMarkerWrapper>
         {prevKeyframe && (
           <KeyframeBlock
             title="Previous"
@@ -67,7 +73,7 @@ export const ActiveMarker = ({ activeMarker, tracks }: ActiveMarkerProps) => {
             percentage={nextMarker!.percentage}
           />
         )}
-      </div>
+      </ActiveMarkerWrapper>
     );
   }
   return (

--- a/src/ActiveMarker.tsx
+++ b/src/ActiveMarker.tsx
@@ -1,34 +1,76 @@
 import React from 'react';
 
 interface ActiveMarkerProps {
-  activeKeyframe: TrackKeyframe;
-  activePercentage: number;
-  prevKeyframe?: TrackKeyframe;
-  prevPercentage: number;
-  nextKeyframe?: TrackKeyframe;
-  nextPercentage: number;
+  activeMarker?: Marker;
+  tracks: TrackWithMarkers[];
 }
 
-export const ActiveMarker = ({
-  activeKeyframe,
-  activePercentage,
-  prevKeyframe,
-  prevPercentage,
-  nextKeyframe,
-  nextPercentage,
-}: ActiveMarkerProps) => {
+interface KeyframeBlockProps {
+  title: string;
+  keyframe: TrackKeyframe;
+  percentage: number;
+  active?: boolean;
+}
+
+const KeyframeBlock = ({ title, keyframe, percentage }: KeyframeBlockProps) => {
   return (
     <div>
-      {prevKeyframe && (
-        <div>
-          <h5>Previous keframe: {prevPercentage}%</h5>
-          <p>{JSON.stringify(prevKeyframe.styles)}</p>
-          <h5>Current keyframe: {activePercentage}%</h5>
-          <p>{JSON.stringify(activeKeyframe.styles)}</p>
-          <h5>Next Keyframe: {nextPercentage}%</h5>
-          <p>{JSON.stringify(nextKeyframe?.styles)}</p>
-        </div>
-      )}
+      <h5>
+        {title}: {percentage}%
+      </h5>
+      <p>{JSON.stringify(keyframe.styles)}</p>
     </div>
+  );
+};
+
+export const ActiveMarker = ({ activeMarker, tracks }: ActiveMarkerProps) => {
+  if (activeMarker) {
+    const activeTrack = tracks.find(
+      (track) => track.id === activeMarker?.trackId
+    );
+
+    const activeMarkerIndex = activeTrack!.markers.findIndex(
+      (marker) => marker === activeMarker
+    );
+
+    const prevMarker = activeTrack?.markers[activeMarkerIndex - 1];
+    const nextMarker = activeTrack?.markers[activeMarkerIndex + 1];
+
+    const prevKeyframe =
+      prevMarker &&
+      activeTrack!.keyframes.find((kf) => kf.id === prevMarker.keyframeId);
+    const nextKeyframe =
+      nextMarker &&
+      activeTrack!.keyframes.find((kf) => kf.id === nextMarker.keyframeId);
+    const activeKeyframe = activeTrack?.keyframes.find(
+      (kf) => kf.id === activeMarker?.keyframeId
+    );
+    return (
+      <div>
+        {prevKeyframe && (
+          <KeyframeBlock
+            title="Previous"
+            keyframe={prevKeyframe}
+            percentage={prevMarker!.percentage}
+          />
+        )}
+        <KeyframeBlock
+          title="Selected"
+          keyframe={activeKeyframe!}
+          percentage={activeMarker!.percentage}
+          active
+        />
+        {nextKeyframe && (
+          <KeyframeBlock
+            title="Next"
+            keyframe={nextKeyframe}
+            percentage={nextMarker!.percentage}
+          />
+        )}
+      </div>
+    );
+  }
+  return (
+    <div>Select a keyframe on the timeline to view and edit it's styles</div>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,43 +127,6 @@ export const App = () => {
     setTracks(updatedTracks);
   };
 
-  const getActiveMarker = () => {
-    if (activeMarker) {
-      const activeTrack = tracksWithMarkers.find(
-        (track) => track.id === activeMarker.trackId
-      );
-
-      const activeMarkerIndex = activeTrack!.markers.findIndex(
-        (marker) => marker === activeMarker
-      );
-
-      const prevMarker = activeTrack!.markers[activeMarkerIndex - 1];
-      const nextMarker = activeTrack!.markers[activeMarkerIndex + 1];
-
-      const prevKeyframe =
-        prevMarker &&
-        activeTrack!.keyframes.find((kf) => kf.id === prevMarker.keyframeId);
-      const nextKeyframe =
-        nextMarker &&
-        activeTrack!.keyframes.find((kf) => kf.id === nextMarker.keyframeId);
-      const activeKeyframe = activeTrack!.keyframes.find(
-        (kf) => kf.id === activeMarker.keyframeId
-      );
-
-      return (
-        <ActiveMarker
-          prevKeyframe={prevKeyframe}
-          prevPercentage={prevMarker?.percentage}
-          activeKeyframe={activeKeyframe!}
-          activePercentage={activeMarker?.percentage}
-          nextKeyframe={nextKeyframe}
-          nextPercentage={nextMarker.percentage}
-        />
-      );
-    }
-    return null;
-  };
-
   return (
     <AppWrapper>
       <Previews>
@@ -173,13 +136,15 @@ export const App = () => {
           animationStyles={tracksToStyles(tracks, animationProperties)}
         />
       </Previews>
-      {getActiveMarker()}
-      <Tracks
-        addNewTrack={addNewTrack}
-        tracks={tracksWithMarkers}
-        setActiveMarker={setActiveMarker}
-        updateKeyframe={updateKeyframe}
-      />
+      <div>
+        <ActiveMarker tracks={tracksWithMarkers} activeMarker={activeMarker} />
+        <Tracks
+          addNewTrack={addNewTrack}
+          tracks={tracksWithMarkers}
+          setActiveMarker={setActiveMarker}
+          updateKeyframe={updateKeyframe}
+        />
+      </div>
     </AppWrapper>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,10 @@ const Previews = styled.div`
   height: 40vh;
 `;
 
+const TracksContainer = styled.div`
+  display: flex;
+`;
+
 export const App = () => {
   const [
     animationProperties,
@@ -136,15 +140,15 @@ export const App = () => {
           animationStyles={tracksToStyles(tracks, animationProperties)}
         />
       </Previews>
-      <div>
-        <ActiveMarker tracks={tracksWithMarkers} activeMarker={activeMarker} />
+      <TracksContainer>
         <Tracks
           addNewTrack={addNewTrack}
           tracks={tracksWithMarkers}
           setActiveMarker={setActiveMarker}
           updateKeyframe={updateKeyframe}
         />
-      </div>
+        <ActiveMarker tracks={tracksWithMarkers} activeMarker={activeMarker} />
+      </TracksContainer>
     </AppWrapper>
   );
 };

--- a/src/Tracks.tsx
+++ b/src/Tracks.tsx
@@ -1,4 +1,5 @@
 import React, { useState, createRef, useEffect } from 'react';
+import styled from 'styled-components';
 import { Track } from './Track';
 
 interface TracksProps {
@@ -12,6 +13,10 @@ interface TracksProps {
     styles: string | null
   ) => void;
 }
+
+const TracksContainer = styled.div`
+  flex-grow: 1;
+`;
 
 export const Tracks = ({
   addNewTrack,
@@ -64,16 +69,27 @@ export const Tracks = ({
       const percentages = keyframe!.percentages.map((percentage, index) => {
         if (index == percentageIndex) return xPercentage;
         return percentage;
-      })
+      });
 
-      updateKeyframe(draggedMarker.trackId, draggedMarker.keyframeId, percentages, null);
+      updateKeyframe(
+        draggedMarker.trackId,
+        draggedMarker.keyframeId,
+        percentages,
+        null
+      );
     }
-  }
+  };
 
   return (
-    <div ref={containerRef} onMouseMove={onMouseMove}>
+    <TracksContainer ref={containerRef} onMouseMove={onMouseMove}>
       {tracks.map((track) => (
-        <Track track={track} width={width} setDraggedMarker={setDraggedMarker} setActiveMarker={setActiveMarker} key={track.id} />
+        <Track
+          track={track}
+          width={width}
+          setDraggedMarker={setDraggedMarker}
+          setActiveMarker={setActiveMarker}
+          key={track.id}
+        />
       ))}
       <form>
         <label htmlFor="selectors">Selectors (separated by ,)</label>
@@ -85,6 +101,6 @@ export const Tracks = ({
         />
         <button onClick={onAddNewTrack}>Add new track</button>
       </form>
-    </div>
+    </TracksContainer>
   );
 };


### PR DESCRIPTION
Currently the styles for the selected keyframe are dumped out in the page anywhere, just to prove they're being held in state.

The intention is to have these shown in a panel to the right of the Tracks.

This PR moves them into place, and refactors some of the behaviour related to determining the active keyframe to make this process easier.