### PR TITLE
Add animation management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,10 +137,7 @@ export const App = () => {
       <AppWrapper>
         <Previews>
           <MarkupInput markup={markup} setMarkup={setMarkup} />
-          <Preview
-            markup={markup}
-            animationStyles={tracksToStyles(tracks, animationProperties)}
-          />
+          <Preview markup={markup} tracks={tracks} />
         </Previews>
         <TracksContainer>
           <Tracks

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Preview } from './Preview';
 import { tracksToStyles } from './helpers/tracksToStyles';
 import { keyframesToMarkers } from './helpers/keyframesToMarkers';
 import { ActiveMarker } from './ActiveMarker';
+import { AnimationManagerProvider } from './context/AnimationManagerContext';
 
 const generateId = () => Date.now();
 
@@ -132,23 +133,28 @@ export const App = () => {
   };
 
   return (
-    <AppWrapper>
-      <Previews>
-        <MarkupInput markup={markup} setMarkup={setMarkup} />
-        <Preview
-          markup={markup}
-          animationStyles={tracksToStyles(tracks, animationProperties)}
-        />
-      </Previews>
-      <TracksContainer>
-        <Tracks
-          addNewTrack={addNewTrack}
-          tracks={tracksWithMarkers}
-          setActiveMarker={setActiveMarker}
-          updateKeyframe={updateKeyframe}
-        />
-        <ActiveMarker tracks={tracksWithMarkers} activeMarker={activeMarker} />
-      </TracksContainer>
-    </AppWrapper>
+    <AnimationManagerProvider animationProperties={animationProperties}>
+      <AppWrapper>
+        <Previews>
+          <MarkupInput markup={markup} setMarkup={setMarkup} />
+          <Preview
+            markup={markup}
+            animationStyles={tracksToStyles(tracks, animationProperties)}
+          />
+        </Previews>
+        <TracksContainer>
+          <Tracks
+            addNewTrack={addNewTrack}
+            tracks={tracksWithMarkers}
+            setActiveMarker={setActiveMarker}
+            updateKeyframe={updateKeyframe}
+          />
+          <ActiveMarker
+            tracks={tracksWithMarkers}
+            activeMarker={activeMarker}
+          />
+        </TracksContainer>
+      </AppWrapper>
+    </AnimationManagerProvider>
   );
 };

--- a/src/PlayControls.tsx
+++ b/src/PlayControls.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  PlayStates,
+  useAnimationManager,
+} from './context/AnimationManagerContext';
+
+const ControlsContainer = styled.div`
+  display: flex;
+`;
+
+const ControlButton = styled.button`
+  flex: 1 1 auto;
+`;
+
+export const PlayControls = () => {
+  const {
+    pause,
+    resume,
+    stepForward,
+    stepBackward,
+    playState,
+  } = useAnimationManager();
+
+  const playPauseButton =
+    playState === PlayStates.playing ? (
+      <ControlButton onClick={pause}>⏸</ControlButton>
+    ) : (
+      <ControlButton onClick={resume}>▶</ControlButton>
+    );
+
+  return (
+    <ControlsContainer>
+      <ControlButton onClick={stepBackward}>⏮️</ControlButton>
+      {playPauseButton}
+      <ControlButton onClick={stepForward}>⏭️</ControlButton>
+    </ControlsContainer>
+  );
+};

--- a/src/Playhead.tsx
+++ b/src/Playhead.tsx
@@ -1,0 +1,32 @@
+import React, { createRef, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+import { useAnimationManager } from './context/AnimationManagerContext';
+
+interface PlayheadProps {
+  width: number;
+}
+
+const Playbar = styled.div`
+  position: absolute;
+  height: 100%;
+  width: 0;
+  border-left: 1px solid blue;
+`;
+
+export const Playhead = ({ width }: PlayheadProps) => {
+  const playheadRef = createRef<HTMLDivElement>();
+  const { addAnimation } = useAnimationManager();
+
+  const playheadKeyframes = [
+    { transform: 'none' },
+    { transform: `translateX(${width}px)` },
+  ];
+
+  useEffect(() => {
+    if (playheadRef.current) {
+      addAnimation(playheadRef.current, playheadKeyframes);
+    }
+  }, [playheadRef]);
+
+  return <Playbar ref={playheadRef} />;
+};

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -1,10 +1,17 @@
 import React, { createRef } from 'react';
+import styled from 'styled-components';
 import { useAnimationManager } from './context/AnimationManagerContext';
+import { PlayControls } from './PlayControls';
 
 interface PreviewProps {
   markup: string;
   tracks: Track[];
 }
+
+const PreviewContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
 
 export const Preview = ({ markup, tracks }: PreviewProps) => {
   const iframeRef = createRef<HTMLIFrameElement>();
@@ -41,11 +48,14 @@ export const Preview = ({ markup, tracks }: PreviewProps) => {
     </html>
   `;
   return (
-    <iframe
-      sandbox="allow-same-origin"
-      srcDoc={srcDoc}
-      ref={iframeRef}
-      onLoad={onIframeLoad}
-    />
+    <PreviewContainer>
+      <iframe
+        sandbox="allow-same-origin"
+        srcDoc={srcDoc}
+        ref={iframeRef}
+        onLoad={onIframeLoad}
+      />
+      <PlayControls />
+    </PreviewContainer>
   );
 };

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -1,28 +1,51 @@
-import React from 'react';
+import React, { createRef } from 'react';
+import { useAnimationManager } from './context/AnimationManagerContext';
 
 interface PreviewProps {
   markup: string;
-  animationStyles: string;
+  tracks: Track[];
 }
 
-export const Preview = ({ markup, animationStyles }: PreviewProps) => {
+export const Preview = ({ markup, tracks }: PreviewProps) => {
+  const iframeRef = createRef<HTMLIFrameElement>();
+  const { addAnimation } = useAnimationManager();
+
+  const onIframeLoad = () => {
+    const { contentWindow } = iframeRef.current!;
+
+    tracks.forEach((track) => {
+      const keyframes = track.keyframes
+        .reduce((keyframes: Keyframe[], keyframe: TrackKeyframe) => {
+          const frames = keyframe.percentages.map((percentage) => ({
+            ...keyframe.styles,
+            offset: percentage / 100,
+          }));
+          return [...keyframes, ...frames];
+        }, [])
+        .sort((a, b) => a.offset! - b.offset!);
+
+      const elements = track.selectors.flatMap((selector) => {
+        return Array.from(contentWindow!.document.querySelectorAll(selector));
+      });
+
+      elements.forEach((element) => addAnimation(element, keyframes));
+    });
+  };
+
   const srcDoc = `
     <!DOCTYPE html>
     <html lang="en" >
-
-    <head>
-
-    
-    <style>
-      ${animationStyles}
-    </style>
-
-    </head>
-
-    <body translate="no" >
-      ${markup}
-    </body>
+      <body>
+        ${markup}
+      </body>
     </html>
   `;
-  return <iframe sandbox="allow-same-origin" srcDoc={srcDoc} />;
+  return (
+    <iframe
+      sandbox="allow-same-origin"
+      srcDoc={srcDoc}
+      ref={iframeRef}
+      onLoad={onIframeLoad}
+    />
+  );
 };

--- a/src/Preview.tsx
+++ b/src/Preview.tsx
@@ -24,5 +24,5 @@ export const Preview = ({ markup, animationStyles }: PreviewProps) => {
     </body>
     </html>
   `;
-  return <iframe sandbox="" srcDoc={srcDoc} />;
+  return <iframe sandbox="allow-same-origin" srcDoc={srcDoc} />;
 };

--- a/src/Tracks.tsx
+++ b/src/Tracks.tsx
@@ -1,5 +1,6 @@
 import React, { useState, createRef, useEffect } from 'react';
 import styled from 'styled-components';
+import { Playhead } from './Playhead';
 import { Track } from './Track';
 
 interface TracksProps {
@@ -82,6 +83,7 @@ export const Tracks = ({
 
   return (
     <TracksContainer ref={containerRef} onMouseMove={onMouseMove}>
+      <Playhead width={width} />
       {tracks.map((track) => (
         <Track
           track={track}

--- a/src/context/AnimationManagerContext.tsx
+++ b/src/context/AnimationManagerContext.tsx
@@ -1,0 +1,66 @@
+import React, { createContext, useContext } from 'react';
+
+interface AnimationManagerValues {
+  addAnimation: (element: Element, keyframes: Keyframe[]) => void;
+  pause: () => void;
+  resume: () => void;
+}
+
+interface AnimationManagerProviderProps {
+  children: React.ReactNode;
+  animationProperties: AnimationProperties;
+}
+
+const AnimationManagerContext = createContext<
+  AnimationManagerValues | undefined
+>(undefined);
+
+export const AnimationManagerProvider = ({
+  children,
+  animationProperties,
+}: AnimationManagerProviderProps) => {
+  const animationTiming = {
+    duration: animationProperties.duration,
+    iterations: Infinity,
+  };
+
+  const addAnimation = (element: Element, keyframes: Keyframe[]) => {
+    const existingAnimation = document.getAnimations().find((animation) => {
+      const effect = animation.effect as KeyframeEffect;
+      return effect?.target === element;
+    });
+    if (existingAnimation) existingAnimation.cancel();
+
+    element.animate(keyframes, animationTiming);
+  };
+
+  const pause = () => {
+    document.getAnimations().forEach((animation) => animation.pause());
+  };
+
+  const resume = () => {
+    document.getAnimations().forEach((animation) => animation.play());
+  };
+
+  return (
+    <AnimationManagerContext.Provider
+      value={{
+        addAnimation,
+        pause,
+        resume,
+      }}
+    >
+      {children}
+    </AnimationManagerContext.Provider>
+  );
+};
+
+export const useAnimationManager = (): AnimationManagerValues => {
+  const context = useContext(AnimationManagerContext);
+  if (context === undefined) {
+    throw new Error(
+      'useAnimationManager can only be called from inside an AnimationManagerProvider'
+    );
+  }
+  return context;
+};

--- a/src/context/AnimationManagerContext.tsx
+++ b/src/context/AnimationManagerContext.tsx
@@ -1,6 +1,12 @@
-import React, { createContext, useContext, useRef } from 'react';
+import React, { createContext, useContext, useRef, useState } from 'react';
+
+export enum PlayStates {
+  playing,
+  paused,
+}
 
 interface AnimationManagerValues {
+  playState: PlayStates;
   addAnimation: (element: Element, keyframes: Keyframe[]) => void;
   pause: () => void;
   resume: () => void;
@@ -22,6 +28,7 @@ export const AnimationManagerProvider = ({
   animationProperties,
 }: AnimationManagerProviderProps) => {
   const animations = useRef<Animation[]>([]);
+  const [playState, setPlayState] = useState<PlayStates>(PlayStates.playing);
 
   const animationTiming = {
     duration: animationProperties.duration,
@@ -40,16 +47,25 @@ export const AnimationManagerProvider = ({
     }
 
     const animation = element.animate(keyframes, animationTiming);
+
+    const currentTime = current[0]?.currentTime || 0;
+    if (playState === PlayStates.paused) {
+      animation.pause();
+    }
+    animation.currentTime = currentTime;
+
     current.push(animation);
     animations.current = current;
   };
 
   const pause = () => {
     animations.current.forEach((animation) => animation.pause());
+    setPlayState(PlayStates.paused);
   };
 
   const resume = () => {
     animations.current.forEach((animation) => animation.play());
+    setPlayState(PlayStates.playing);
   };
 
   const stepForward = () => {
@@ -74,6 +90,7 @@ export const AnimationManagerProvider = ({
         resume,
         stepForward,
         stepBackward,
+        playState,
       }}
     >
       {children}

--- a/src/context/AnimationManagerContext.tsx
+++ b/src/context/AnimationManagerContext.tsx
@@ -4,6 +4,8 @@ interface AnimationManagerValues {
   addAnimation: (element: Element, keyframes: Keyframe[]) => void;
   pause: () => void;
   resume: () => void;
+  stepForward: () => void;
+  stepBackward: () => void;
 }
 
 interface AnimationManagerProviderProps {
@@ -50,12 +52,28 @@ export const AnimationManagerProvider = ({
     animations.current.forEach((animation) => animation.play());
   };
 
+  const stepForward = () => {
+    const currentTime = animations.current[0].currentTime;
+    animations.current.forEach(
+      (animation) => (animation.currentTime = Math.floor(currentTime || 0) + 10)
+    );
+  };
+
+  const stepBackward = () => {
+    const currentTime = animations.current[0].currentTime;
+    animations.current.forEach(
+      (animation) => (animation.currentTime = Math.floor(currentTime || 0) - 10)
+    );
+  };
+
   return (
     <AnimationManagerContext.Provider
       value={{
         addAnimation,
         pause,
         resume,
+        stepForward,
+        stepBackward,
       }}
     >
       {children}


### PR DESCRIPTION
I wanted to add a Playhead, a vertical line on the Tracks component that shows the current progress of the animation in the Preview.

In order to do that, I needed a way to manage multiple animations in sync; the animation of the Playhead and all the animations in the Preview.  For this, I have created a React context called AnimationManagerContext.

This context manages the creation of Web Animation API animations and keeps them in sync.  It provides methods to pause, resume and step through the animations synchronously.  This also necessitated converting the animations in the Preview from CSS `@keyframes` animations to Web Animation API animations.

With these new methods, I've also added playback controls, so the user can click buttons to control the animation playback.

The message on each commit in this PR explains the intricacies of the code it adds.  I would recommend reading them and I'd welcome any feedback on anything in the commit message that's not clear.