### PR TITLE
Highlight the currently active marker

### DIFF
--- a/src/ActiveMarker.tsx
+++ b/src/ActiveMarker.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import React, { MouseEventHandler } from 'react';
 import styled from 'styled-components';
 
 interface ActiveMarkerProps {
   activeMarker?: Marker;
   tracks: TrackWithMarkers[];
+  setActiveMarker: (marker: Marker) => void;
 }
 
 interface KeyframeBlockProps {
   title: string;
   keyframe: TrackKeyframe;
   percentage: number;
-  active?: boolean;
+  activate?: () => void;
 }
 
 const ActiveMarkerWrapper = styled.div`
@@ -18,9 +19,17 @@ const ActiveMarkerWrapper = styled.div`
   padding: 20px;
 `;
 
-const KeyframeBlock = ({ title, keyframe, percentage }: KeyframeBlockProps) => {
+const KeyframeBlock = ({
+  title,
+  keyframe,
+  percentage,
+  activate,
+}: KeyframeBlockProps) => {
+  const onClick: MouseEventHandler<HTMLDivElement> = () => {
+    activate && activate();
+  };
   return (
-    <div>
+    <div onClick={onClick}>
       <h5>
         {title}: {percentage}%
       </h5>
@@ -29,7 +38,11 @@ const KeyframeBlock = ({ title, keyframe, percentage }: KeyframeBlockProps) => {
   );
 };
 
-export const ActiveMarker = ({ activeMarker, tracks }: ActiveMarkerProps) => {
+export const ActiveMarker = ({
+  activeMarker,
+  tracks,
+  setActiveMarker,
+}: ActiveMarkerProps) => {
   if (activeMarker) {
     const activeTrack = tracks.find(
       (track) => track.id === activeMarker?.trackId
@@ -53,24 +66,25 @@ export const ActiveMarker = ({ activeMarker, tracks }: ActiveMarkerProps) => {
     );
     return (
       <ActiveMarkerWrapper>
-        {prevKeyframe && (
+        {prevKeyframe && prevMarker && (
           <KeyframeBlock
             title="Previous"
             keyframe={prevKeyframe}
             percentage={prevMarker!.percentage}
+            activate={() => setActiveMarker(prevMarker)}
           />
         )}
         <KeyframeBlock
           title="Selected"
           keyframe={activeKeyframe!}
           percentage={activeMarker!.percentage}
-          active
         />
-        {nextKeyframe && (
+        {nextKeyframe && nextMarker && (
           <KeyframeBlock
             title="Next"
             keyframe={nextKeyframe}
             percentage={nextMarker!.percentage}
+            activate={() => setActiveMarker(nextMarker)}
           />
         )}
       </ActiveMarkerWrapper>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,6 +142,7 @@ export const App = () => {
         <TracksContainer>
           <Tracks
             addNewTrack={addNewTrack}
+            activeMarker={activeMarker}
             tracks={tracksWithMarkers}
             setActiveMarker={setActiveMarker}
             updateKeyframe={updateKeyframe}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,6 +149,7 @@ export const App = () => {
           <ActiveMarker
             tracks={tracksWithMarkers}
             activeMarker={activeMarker}
+            setActiveMarker={setActiveMarker}
           />
         </TracksContainer>
       </AppWrapper>

--- a/src/Track.tsx
+++ b/src/Track.tsx
@@ -5,23 +5,30 @@ interface TrackProps {
   track: TrackWithMarkers;
   width: number;
   setActiveMarker: (marker: Marker) => void;
+  activeMarker?: Marker;
   setDraggedMarker: (marker: MarkerWithIndex | null) => void;
 }
 
 interface MarkerProps {
-  x: number;
-  id: number;
+  active: boolean;
 }
 
-const Marker = styled.path`
+const Marker = styled.path<MarkerProps>`
   cursor: pointer;
+  ${(props) => props.active && `fill: blue`}
 `;
 
-export const Track = ({ track, width, setDraggedMarker, setActiveMarker }: TrackProps) => {
+export const Track = ({
+  track,
+  width,
+  setDraggedMarker,
+  setActiveMarker,
+  activeMarker,
+}: TrackProps) => {
   const setTransform = (width: number, percentage: number) => {
     const x = (width / 100) * percentage;
     return `translate(${x} 0)`;
-  }
+  };
 
   return (
     <div>
@@ -39,11 +46,14 @@ export const Track = ({ track, width, setDraggedMarker, setActiveMarker }: Track
                 setActiveMarker(marker);
               }}
               onMouseDown={() => {
-                setDraggedMarker(Object.assign({percentageIndex: index}, marker));
+                setDraggedMarker(
+                  Object.assign({ percentageIndex: index }, marker)
+                );
               }}
               onMouseUp={() => {
                 setDraggedMarker(null);
               }}
+              active={marker === activeMarker}
             />
           );
         })}

--- a/src/Tracks.tsx
+++ b/src/Tracks.tsx
@@ -6,6 +6,7 @@ import { Track } from './Track';
 interface TracksProps {
   tracks: TrackWithMarkers[];
   addNewTrack: (selectors: string[]) => void;
+  activeMarker?: Marker;
   setActiveMarker: (marker: Marker) => void;
   updateKeyframe: (
     trackId: number,
@@ -23,11 +24,14 @@ export const Tracks = ({
   addNewTrack,
   tracks,
   setActiveMarker,
-  updateKeyframe
+  activeMarker,
+  updateKeyframe,
 }: TracksProps) => {
   const [width, setWidth] = useState<number>(0);
   const [newSelector, setNewSelector] = useState<string>('');
-  const [draggedMarker, setDraggedMarker] = useState<MarkerWithIndex | null>(null);
+  const [draggedMarker, setDraggedMarker] = useState<MarkerWithIndex | null>(
+    null
+  );
 
   const containerRef = createRef<HTMLDivElement>();
 
@@ -39,8 +43,6 @@ export const Tracks = ({
         setWidth(containerRef.current.getBoundingClientRect().width);
       }
     };
-
-
 
     updateWidth();
     window.addEventListener('resize', updateWidth);
@@ -62,7 +64,7 @@ export const Tracks = ({
   };
 
   const onMouseMove = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    const xPercentage = ((e.clientX / width) * 100);
+    const xPercentage = (e.clientX / width) * 100;
     if (draggedMarker) {
       const { trackId, keyframeId, percentageIndex } = draggedMarker;
       const track = tracks.find(({ id }) => id == trackId);
@@ -90,6 +92,7 @@ export const Tracks = ({
           width={width}
           setDraggedMarker={setDraggedMarker}
           setActiveMarker={setActiveMarker}
+          activeMarker={activeMarker}
           key={track.id}
         />
       ))}


### PR DESCRIPTION
It's not currently easy to identify which marker on the screen is the selected one.
This PR fixes that by changing the colour of the active marker to blue.

It also allows users to click the next or previous keyframe's contents in the ActiveMarker component to activate that marker.